### PR TITLE
Allow protection of nested members

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,33 @@ function protectClientPayload(clientPayload, exceptAllowlist) {
 
     console.log('Protecting members from client_payload:')
 
-    Object.keys(clientPayload)
-        .filter(memberName => !exceptAllowlist.includes(memberName))
-        .forEach(memberName => {
+    recurseMembers(clientPayload,
+        (val, memberName) => {
+            if (exceptAllowlist.includes(memberName)) {
+                return
+            }
+
             core.info(`- protecting ${memberName}`)
-
-            let val = clientPayload[memberName]
-
             if (val) {
-                val = val.toString()
-                core.setSecret(val)
+                core.setSecret(val.toString())
             }
         })
+}
+
+function recurseMembers(obj, memberCallback, path) {
+    const members = Object.keys(obj)
+
+    path = path || []
+
+    for (let member of members) {
+        const val = obj[member]
+        const memberPath = [...path, member]
+        if (typeof val === 'object') {
+            recurseMembers(val, memberCallback, memberPath)
+        } else {
+            memberCallback(val, memberPath.join('.'))
+        }
+    }
 }
 
 try {


### PR DESCRIPTION
This allows a payload like:

```json
{
    "memberA": "a",
    "memberB": {
        "nested": "b.nested"
    }
}
```

... to have its members protected properly. Allowing nested members through means specifying each by its path; taking the above example, `memberB.nested` would prevent the `b.nested` value from being marked as a secret.